### PR TITLE
feat(exclude): add exclude pattern for rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyraiq-tslint-custom-rules",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "hyraiq-tslint-custom-rules.json",
   "scripts": {

--- a/src/noMissingTestsRule.ts
+++ b/src/noMissingTestsRule.ts
@@ -4,7 +4,6 @@ import * as Lint from 'tslint';
 import * as ts from 'typescript';
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = 'Missing test case';
 
     public static metadata: Lint.IRuleMetadata = {
         ruleName: 'no-missing-tests',
@@ -20,6 +19,12 @@ export class Rule extends Lint.Rules.AbstractRule {
                 testBase: {
                     type: 'string',
                 },
+                exclude: {
+                    type: 'array',
+                    items: {
+                        type: 'string',
+                    },
+                },
             },
         },
         optionExamples: [[true, 'log', 'error']],
@@ -30,18 +35,41 @@ export class Rule extends Lint.Rules.AbstractRule {
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk, this.ruleArguments[0]);
     }
+
+    public static makeErrorString(expectedPath: string) {
+        return `Test case for file not found in ${expectedPath}`;
+    }
 }
 
 interface IRuleOptions {
     srcBase: string;
     testBase: string;
+    exclude: string[];
 }
 
 function walk(ctx: Lint.WalkContext<IRuleOptions>) {
     const relativePath = path.relative(process.cwd(), ctx.sourceFile.fileName).replace(ctx.options.srcBase, '');
     const basename = relativePath.replace(path.parse(relativePath).ext, '');
+
+    if (isExcluded(relativePath, ctx.options.exclude)) {
+        return;
+    }
+
     const testFile = `${path.join(ctx.options.testBase, basename)}.spec.js`;
     if (!fs.existsSync(testFile)) {
-        ctx.addFailureAtNode(ctx.sourceFile, Rule.FAILURE_STRING);
+        ctx.addFailureAtNode(ctx.sourceFile, Rule.makeErrorString(testFile));
     }
+}
+
+function isExcluded(filePath: string, excludePatterns: string[]) {
+    for (const excludePattern of excludePatterns) {
+        const regex = new RegExp(excludePattern);
+        const result = filePath.match(regex);
+
+        if (null !== result && 0 !== result.length) {
+            return true;
+        }
+    }
+
+    return false;
 }


### PR DESCRIPTION
I think best here would be actually to pass in a list of tokens that, if present in the source file, enforces the rule. I.e. If there is a `class` or `function` or `() => {}` token or whatever. But that is more effort and this is fine